### PR TITLE
docs: restore broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ Full installation, deployment and Docker instructions live in the [deployment gu
 
 Pull requests are welcome; for major changes, open an issue first to discuss direction. Prompt data contributions — adding or refining tags for a language — are especially appreciated, and the files are plain JSON with no tooling required.
 
+## Star History
+
+[![Star History Chart](https://star-history.dera.page/svg?repos=rockbenben/img-prompt&type=Date)](https://star-history.dera.page/#rockbenben/img-prompt&Date)
+
 ## Credits and licensing
 
 IMGPrompt's own code is [MIT](LICENSE). The prompt library is aggregated and curated from several open sources — huge thanks to:

--- a/README.zh.md
+++ b/README.zh.md
@@ -72,6 +72,10 @@ yarn lint
 
 欢迎 PR，较大的改动建议先开 Issue 讨论方向。提示词数据相关的贡献尤其欢迎——文件都是标准 JSON，不需要额外工具链，直接改就行。
 
+## Star 历史
+
+[![Star History Chart](https://star-history.dera.page/svg?repos=rockbenben/img-prompt&type=Date)](https://star-history.dera.page/#rockbenben/img-prompt&Date)
+
 ## 致谢与授权
 
 IMGPrompt 自身代码采用 [MIT](LICENSE) 协议。提示词数据汇集并整理自多个开源项目，特别感谢：


### PR DESCRIPTION
This restores the Star History section that was dropped from the READMEs in 5f8a3c2 ("docs"). The old chart relied on the GitHub stargazer API, which now rate-limits and breaks the rendering. The chart has been switched to a data source that works without an API token, so the star history graph displays again.